### PR TITLE
Update to use chefDK as a package.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,11 +24,11 @@ suites:
                 notification: {
                   email: {
                     enabled: false,
-                    maintainers_email: 'bcarr@commercehub.com'
+                    maintainers_email: 'email@example.com'
                   },
                   hipchat: {
                     enabled: false,
-                    hipchat_room: 'Brian Carr'
+                    hipchat_room: 'Chef'
                   }
                 },
                 steps: {

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,15 +20,15 @@ suites:
             cookbooks: [
               {
                 cookbook_name: 'sous_chef',
-                cookbook_url: 'https://github.com/commercehub-oss/sous_chef.git',
+                cookbook_url: 'https://git.nexus.commercehub.com/lzarou/sous_chef.git',
                 notification: {
                   email: {
                     enabled: false,
-                    maintainers_email: 'email@example.com'
+                    maintainers_email: 'bcarr@commercehub.com'
                   },
                   hipchat: {
                     enabled: false,
-                    hipchat_room: 'Chef'
+                    hipchat_room: 'Brian Carr'
                   }
                 },
                 steps: {

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,7 +20,7 @@ suites:
             cookbooks: [
               {
                 cookbook_name: 'sous_chef',
-                cookbook_url: 'https://git.nexus.commercehub.com/lzarou/sous_chef.git',
+                cookbook_url: 'git@github.com:commercehub-oss/sous_chef.git',
                 notification: {
                   email: {
                     enabled: false,

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,7 +20,7 @@ suites:
             cookbooks: [
               {
                 cookbook_name: 'sous_chef',
-                cookbook_url: 'git@github.com:commercehub-oss/sous_chef.git',
+                cookbook_url: 'https://github.com/commercehub-oss/sous_chef.git',
                 notification: {
                   email: {
                     enabled: false,

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '= 3.2.3'
-gem 'berkshelf-api-client', '= 1.2.1'
-gem 'foodcritic', '= 4.0.0'
 gem 'serverspec'
-gem 'test-kitchen'
-gem 'kitchen-vagrant'
 gem 'busser-serverspec'
-gem 'rubocop'
 gem 'thor'
 gem 'thor-scmversion'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
+gem 'berkshelf', '= 3.2.3'
+gem 'berkshelf-api-client', '= 1.2.1'
 gem 'foodcritic'
 gem 'serverspec'
 gem 'test-kitchen'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'berkshelf', '= 3.2.3'
 gem 'berkshelf-api-client', '= 1.2.1'
-gem 'foodcritic'
+gem 'foodcritic', '= 4.0.0'
 gem 'serverspec'
 gem 'test-kitchen'
 gem 'kitchen-vagrant'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To setup just the jenkins server with no cookbook jobs refer to [Jenkins Server]
 
 In addition to configuring the jenkins server with everything needed to start cookbook testing, Sous_Chef provides an attribute driven system to create jenkins jobs for cookbooks.  This job will represent the deployment pipeline for the chef cookbook.  These jobs will be broken into several steps as part of a cookbook testing pipeline. These steps include:
 
-* chef gem install
+* chef exec bundle install
 * rubocop
 * foodcritic
 * test_kitchen
@@ -242,7 +242,7 @@ default['sous_chef']['default_cookbook'] =
       steps: {
         bundle: {
           enabled: true,
-          command: 'chef gem install kitchen-vsphere'
+          command: 'chef exec bundle install'
         },
         rubocop: {
           enabled: true,

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Requirements
 This cookbook depends on several other cookbooks to accomplish the task of configuring a jenkins server to test cookbooks.
 
 * 'jenkins'
+* 'chef-dk'
 * 'git'
 * 'build-essential'
 * 'apt'
@@ -42,7 +43,7 @@ To setup just the jenkins server with no cookbook jobs refer to [Jenkins Server]
 
 In addition to configuring the jenkins server with everything needed to start cookbook testing, Sous_Chef provides an attribute driven system to create jenkins jobs for cookbooks.  This job will represent the deployment pipeline for the chef cookbook.  These jobs will be broken into several steps as part of a cookbook testing pipeline. These steps include:
 
-* bundle install
+* chef gem install
 * rubocop
 * foodcritic
 * test_kitchen
@@ -241,19 +242,19 @@ default['sous_chef']['default_cookbook'] =
       steps: {
         bundle: {
           enabled: true,
-          command: 'bundle install --path vendor/bundle'
+          command: 'chef gem install kitchen-vsphere'
         },
         rubocop: {
           enabled: true,
-          command: 'bundle exec rubocop'
+          command: 'rubocop'
         },
         foodcritic: {
           enabled: true,
-          command: 'bundle exec foodcritic . -f any'
+          command: 'foodcritic . -f any'
         },
         test_kitchen: {
           enabled: true,
-          command: 'bundle exec kitchen test'
+          command: 'kitchen test'
         },
         version: {
           enabled: false,

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,66 @@
 ## sous_chef
 default['sous_chef']['cookbooks'] = []
 default['sous_chef']['merged_cookbooks'] = []
+default['sous_chef']['merged_chef_repos'] = []
+default['sous_chef']['manage_chef_repo'] = false
+
+default['sous_chef']['default_chef_repo'] =
+    {
+      chef_repo_name: '',
+      chef_repo_url: '',
+      notification: {
+        email: {
+          enabled: true,
+          maintainers_email: 'email@example.com'
+        },
+        hipchat: {
+          enabled: false,
+          hipchat_room: '',
+          notifyStarted: false,
+          notifySuccess: true,
+          notifyAborted: true,
+          notifyNotBuilt: false,
+          notifyUnstable: true,
+          notifyFailure: true,
+          notifyBackToNormal: true,
+          startJobMessage: '',
+          completeJobMessage: ''
+        }
+      },
+      triggers: {
+        poll_scm: {
+          enabled: true,
+          schedule: '*/1 * * * *'
+        }
+      },
+      steps: {
+        data_bags: {
+          enabled: true,
+          command: "git diff-tree --no-commit-id --name-only -r $(git log --oneline -n 1 | awk '{print $1}') | grep data_bags | while read line ; do
+                      BAG=$(echo $line | cut -d / -f2)
+                      echo knife data bag from file $BAG $line
+                    done"
+        },
+        environments: {
+          enabled: true,
+          command: "git diff-tree --no-commit-id --name-only -r $(git log --oneline -n 1 | awk '{print $1}') | grep environments | while read line ; do
+                        echo knife environment from file $line
+                      done"
+        },
+        roles: {
+          enabled: true,
+          command: "git diff-tree --no-commit-id --name-only -r $(git log --oneline -n 1 | awk '{print $1}') | grep roles | while read line ; do
+                        echo knife role from file $line
+                      done"
+        },
+        cookbooks: {
+          enabled: true,
+          command: "git diff-tree --no-commit-id --name-only -r $(git log --oneline -n 1 | awk '{print $1}') | grep cookbooks | while read line ; do
+                        echo knife cookbook from file $line
+                      done"
+        }
+      }
+    }
 
 default['sous_chef']['default_cookbook'] =
     {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -114,19 +114,19 @@ default['sous_chef']['default_cookbook'] =
       steps: {
         bundle: {
           enabled: true,
-          command: 'bundle install --path vendor/bundle'
+          command: 'chef gem install kitchen-vsphere'
         },
         rubocop: {
           enabled: true,
-          command: 'bundle exec rubocop'
+          command: 'rubocop'
         },
         foodcritic: {
           enabled: true,
-          command: 'bundle exec foodcritic . -f any'
+          command: 'foodcritic . -f any'
         },
         test_kitchen: {
           enabled: true,
-          command: 'bundle exec kitchen test'
+          command: 'kitchen test'
         },
         version: {
           enabled: false,

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -114,7 +114,7 @@ default['sous_chef']['default_cookbook'] =
       steps: {
         bundle: {
           enabled: true,
-          command: 'chef gem install kitchen-vsphere'
+          command: 'chef exec bundle install'
         },
         rubocop: {
           enabled: true,

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -75,7 +75,8 @@ default['sous_chef']['default_chef_repo'] =
         cookbooks: {
           enabled: true,
           command: "git diff-tree --no-commit-id --name-only -r $(git log --oneline -n 1 | awk '{print $1}') | grep cookbooks | while read line ; do
-                        echo knife cookbook from file $line
+                        COOKBOOK=$(echo $line | cut -d / -f2)
+                        echo knife cookbook upload $COOKBOOK -o $line
                       done"
         }
       }

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ depends 'jenkins'
 depends 'git'
 depends 'build-essential'
 depends 'apt'
+depends 'chef-dk'
 
 # rubocop:disable Style/HashSyntax, Style/AlignParameters
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,10 +7,10 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0.1.0'
 
 depends 'jenkins'
+depends 'chef-dk'
 depends 'git'
 depends 'build-essential'
 depends 'apt'
-depends 'chef-dk'
 
 # rubocop:disable Style/HashSyntax, Style/AlignParameters
 

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -24,7 +24,5 @@ include_recipe 'chef-dk::default'
 
 package 'vagrant'
 package 'zlib1g-dev'
-gem_package 'bundler'
-gem_package 'rake'
 gem_package 'thor'
 gem_package 'thor-scmversion'

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -22,7 +22,6 @@ include_recipe 'build-essential::default'
 include_recipe 'git::default'
 include_recipe 'chef-dk::default'
 
-package 'ruby1.9.3'
 package 'vagrant'
 package 'zlib1g-dev'
 gem_package 'bundler'

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -20,6 +20,7 @@
 include_recipe 'apt'
 include_recipe 'build-essential::default'
 include_recipe 'git::default'
+include_recipe 'chef-dk::default'
 
 package 'ruby1.9.3'
 package 'vagrant'

--- a/recipes/_chef_repo_job.rb
+++ b/recipes/_chef_repo_job.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: sous_chef
+# Recipe::_chef_repo_job
+#
+# Copyright 2015 CommerceHub
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node['sous_chef']['merged_chef_repos'].each do |chef_repo|
+  xml = File.join(Chef::Config['file_cache_path'], "#{chef_repo['chef_repo_name']}.xml")
+
+  template xml do
+    source 'chef_repo_job_xml.erb'
+    variables(
+      chef_repo_url: chef_repo['chef_repo_url'],
+      notification: chef_repo['notification'],
+      triggers: chef_repo['triggers'],
+      steps: chef_repo['steps'],
+      private_keys: node['sous_chef']['jenkins_private_key_credentials']
+    )
+  end
+
+  jenkins_job chef_repo['chef_repo_name'] do
+    config xml
+  end
+end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -50,5 +50,18 @@ node['sous_chef']['cookbooks'].each do |cookbook|
   node.default['sous_chef']['merged_cookbooks'].push(merged_cookbook)
 end
 
+# Cycle through all the chef repos and merge with default chef repo setup
+# Add result to merged_chef_repos array for use later when setting up job steps
+node['sous_chef']['chef_repos'].each do |chef_repo|
+  default_chef_repo = node['sous_chef']['default_chef_repo'].to_hash
+
+  configured_repo = chef_repo
+
+  merged_repo = Chef::Mixin::DeepMerge.deep_merge(configured_repo, default_chef_repo)
+
+  node.default['sous_chef']['merged_chef_repos'].push(merged_repo)
+end
+
 ## Setup Jobs
 include_recipe 'sous_chef::_cookbook_job'
+include_recipe 'sous_chef::_chef_repo_job' if node['sous_chef']['manage_chef_repo']

--- a/roles/test_role.rb
+++ b/roles/test_role.rb
@@ -29,7 +29,7 @@ default_attributes(
         },
         steps: {
           bundle: {
-            command: 'chef gem install kitchen-vsphere'
+            command: 'chef exec bundle install'
           },
           rubocop: {
             command: 'exec rubocop'

--- a/roles/test_role.rb
+++ b/roles/test_role.rb
@@ -8,7 +8,7 @@ default_attributes(
     chef_repos: [
       {
         chef_repo_name: 'chef_repo',
-        chef_repo_url: 'https://git.nexus.commercehub.com/lzarou/test_chef_repo.git',
+        chef_repo_url: '',
         notification: {
           email: {
             enabled: true,

--- a/roles/test_role.rb
+++ b/roles/test_role.rb
@@ -4,6 +4,19 @@ run_list %w(
   recipe[sous_chef::server])
 default_attributes(
   sous_chef: {
+    manage_chef_repo: true,
+    chef_repos: [
+      {
+        chef_repo_name: 'chef_repo',
+        chef_repo_url: 'https://git.nexus.commercehub.com/lzarou/test_chef_repo.git',
+        notification: {
+          email: {
+            enabled: true,
+            maintainers_email: 'email@example.com'
+          }
+        }
+      }
+    ],
     cookbooks: [
       {
         cookbook_name: 'sous_chef',

--- a/roles/test_role.rb
+++ b/roles/test_role.rb
@@ -7,7 +7,7 @@ default_attributes(
     cookbooks: [
       {
         cookbook_name: 'sous_chef',
-        cookbook_url: 'git@github.com:commercehub-oss/sous_chef.git',
+        cookbook_url: 'https://github.com/commercehub-oss/sous_chef.git',
         notification: {
           email: {
             enabled: false,

--- a/roles/test_role.rb
+++ b/roles/test_role.rb
@@ -29,16 +29,16 @@ default_attributes(
         },
         steps: {
           bundle: {
-            command: 'echo bundle install --path vendor/bundle'
+            command: 'chef gem install kitchen-vsphere'
           },
           rubocop: {
-            command: 'echo bundle exec rubocop'
+            command: 'exec rubocop'
           },
           foodcritic: {
-            command: 'echo bundle exec foodcritic . -f any'
+            command: 'exec foodcritic . -f any'
           },
           test_kitchen: {
-            command: 'echo bundle exec kitchen test'
+            command: 'exec kitchen test'
           },
           upload_cookbook: {
             command: 'echo rm -rf replace_with_cookbook

--- a/templates/default/chef_repo_job_xml.erb
+++ b/templates/default/chef_repo_job_xml.erb
@@ -14,7 +14,7 @@
     <% else %>
     <% @private_keys.each do |credential| %>
       <hudson.plugins.git.UserRemoteConfig>
-        <url><%= @cookbook_url %></url>
+        <url><%= @chef_repo_url %></url>
         <credentialsId><%= credential['id'] %></credentialsId>
       </hudson.plugins.git.UserRemoteConfig>
     <% end %>

--- a/templates/default/chef_repo_job_xml.erb
+++ b/templates/default/chef_repo_job_xml.erb
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.3.5">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+    <% if @private_keys.empty? %>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url><%= @chef_repo_url %></url>
+      </hudson.plugins.git.UserRemoteConfig>
+    <% else %>
+    <% @private_keys.each do |credential| %>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url><%= @cookbook_url %></url>
+        <credentialsId><%= credential['id'] %></credentialsId>
+      </hudson.plugins.git.UserRemoteConfig>
+    <% end %>
+    <% end %>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>*/master</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions/>
+  </scm>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <% if @triggers['poll_scm']['enabled'] %>
+    <hudson.triggers.SCMTrigger>
+      <spec><%= @triggers['poll_scm']['schedule'] %></spec>
+      <ignorePostCommitHooks>false</ignorePostCommitHooks>
+    </hudson.triggers.SCMTrigger>
+    <% end %>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <% @steps.each do |step, config| %>
+      <% if config['enabled'] %>
+      <hudson.tasks.Shell>
+          <command><%= config['command'] %></command>
+      </hudson.tasks.Shell>
+      <% end %>
+    <% end %>
+  </builders>
+  <publishers>
+    <% if @notification['email']['enabled'] %>
+    <hudson.tasks.Mailer plugin="mailer@1.11">
+      <recipients><%= @notification['email']['maintainers_email'] %></recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+    <% end %>
+    <% if @notification['hipchat']['enabled'] %>
+    <jenkins.plugins.hipchat.HipChatNotifier plugin="hipchat@0.1.9">
+      <token><%= node['sous_chef']['plugins']['hipchat']['auth_token'] %></token>
+      <room><%= @notification['hipchat']['hipchat_room'] %></room>
+      <startNotification><%= @notification['hipchat']['notifyStarted'] %></startNotification>
+      <notifySuccess><%= @notification['hipchat']['notifySuccess'] %></notifySuccess>
+      <notifyAborted><%= @notification['hipchat']['notifyAborted'] %></notifyAborted>
+      <notifyNotBuilt><%= @notification['hipchat']['notifyNotBuilt'] %></notifyNotBuilt>
+      <notifyUnstable><%= @notification['hipchat']['notifyUnstable'] %></notifyUnstable>
+      <notifyFailure><%= @notification['hipchat']['notifyFailure'] %></notifyFailure>
+      <notifyBackToNormal><%= @notification['hipchat']['notifyBackToNormal'] %></notifyBackToNormal>
+      <startJobMessage><%= @notification['hipchat']['startJobMessage'] %></startJobMessage>
+      <completeJobMessage><%= @notification['hipchat']['completeJobMessage'] %></completeJobMessage>
+    </jenkins.plugins.hipchat.HipChatNotifier>
+    <% end %>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.0">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/templates/default/cookbook_job_xml.erb
+++ b/templates/default/cookbook_job_xml.erb
@@ -7,11 +7,17 @@
   <scm class="hudson.plugins.git.GitSCM" plugin="git@2.3.5">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
+    <% if @private_keys.empty? %>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url><%= @cookbook_url %></url>
+      </hudson.plugins.git.UserRemoteConfig>
+    <% else %>
     <% @private_keys.each do |credential| %>
       <hudson.plugins.git.UserRemoteConfig>
         <url><%= @cookbook_url %></url>
         <credentialsId><%= credential['id'] %></credentialsId>
       </hudson.plugins.git.UserRemoteConfig>
+    <% end %>
     <% end %>
     </userRemoteConfigs>
     <branches>


### PR DESCRIPTION
Update to use chefDK as a package instead of bundler and separate gem files.  Results are more current and more robust (as chefDK routinely uses compatible sets of gem files).